### PR TITLE
Add join pool command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,6 @@
 use crate::farmer::config::{BladebitHarvesterConfig, Config, FarmingInfo, PoolWalletConfig};
 use clap::{Parser, Subcommand};
-use dg_xch_cli::wallets::plotnft_utils::scrounge_for_plotnfts;
+use dg_xch_cli::wallets::plotnft_utils::{get_plotnft_by_launcher_id, scrounge_for_plotnfts};
 use dg_xch_clients::rpc::full_node::FullnodeClient;
 use dg_xch_core::blockchain::sized_bytes::Bytes48;
 use dg_xch_core::consensus::constants::CONSENSUS_CONSTANTS_MAP;
@@ -12,6 +12,7 @@ use dg_xch_keys::{
 use dg_xch_puzzles::clvm_puzzles::launcher_id_to_p2_puzzle_hash;
 use dg_xch_puzzles::p2_delegated_puzzle_or_hidden_puzzle::puzzle_hash_for_pk;
 use dialoguer::Confirm;
+use log::info;
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
@@ -49,6 +50,7 @@ pub enum Action {
         #[arg(short = 'd', long = "plot-directory")]
         plot_directories: Option<Vec<String>>,
     },
+    UpdatePoolInfo {},
 }
 impl Default for Action {
     fn default() -> Self {
@@ -124,8 +126,8 @@ pub async fn generate_config_from_mnemonic(
         &gen_settings.additional_headers,
     );
     let mut page = 0;
-    let mut plotnfs = vec![];
-    while page < 50 && plotnfs.is_empty() {
+    let mut plot_nfts = vec![];
+    while page < 50 && plot_nfts.is_empty() {
         let mut puzzle_hashes = vec![];
         for index in page * 50..(page + 1) * 50 {
             let wallet_sk = master_sk_to_wallet_sk_unhardened(&master_key, index).map_err(|e| {
@@ -145,10 +147,10 @@ pub async fn generate_config_from_mnemonic(
             let pub_key: Bytes48 = hardened_wallet_sk.sk_to_pk().to_bytes().into();
             puzzle_hashes.push(puzzle_hash_for_pk(&pub_key)?);
         }
-        plotnfs.extend(scrounge_for_plotnfts(&client, &puzzle_hashes).await?);
+        plot_nfts.extend(scrounge_for_plotnfts(&client, &puzzle_hashes).await?);
         page += 1;
     }
-    for plot_nft in plotnfs {
+    for plot_nft in plot_nfts {
         config.pool_info.push(PoolWalletConfig {
             difficulty: None,
             launcher_id: plot_nft.launcher_id,
@@ -199,4 +201,69 @@ pub async fn generate_config_from_mnemonic(
         config.save_as_yaml(op)?;
     }
     Ok(config)
+}
+
+pub async fn update_pool_info(config: Config) -> Result<Config, Error> {
+    let client = FullnodeClient::new(
+        &config.fullnode_rpc_host,
+        config.fullnode_rpc_port,
+        config.ssl_root_path.clone(),
+        &None,
+    );
+    let mut plot_nfts = vec![];
+    for farmer_info in &config.farmer_info {
+        if let Some(launcher_id) = farmer_info.launcher_id {
+            info!(
+                "Fetching current PlotNFT state for launcher id {} ...",
+                launcher_id.to_string()
+            );
+            plot_nfts.extend(get_plotnft_by_launcher_id(&client, &launcher_id).await?)
+        }
+    }
+
+    let mut updated_config = config.clone();
+    for plot_nft in plot_nfts {
+        if let Some(pool_wallet) = updated_config
+            .pool_info
+            .iter_mut()
+            .find(|pw| pw.launcher_id == plot_nft.launcher_id)
+        {
+            let old_pool_wallet = pool_wallet.clone();
+            pool_wallet.pool_url = plot_nft.pool_state.pool_url.unwrap_or_default();
+            if pool_wallet.target_puzzle_hash != plot_nft.pool_state.target_puzzle_hash {
+                // Reset diff on pool change
+                pool_wallet.difficulty = None;
+            }
+            pool_wallet.target_puzzle_hash = plot_nft.pool_state.target_puzzle_hash;
+            pool_wallet.owner_public_key = plot_nft.pool_state.owner_pubkey;
+
+            let mut change_messages: Vec<String> = vec![];
+            if old_pool_wallet.pool_url != pool_wallet.pool_url {
+                change_messages.push(format!(
+                    "from {} to {}",
+                    old_pool_wallet.pool_url, pool_wallet.pool_url
+                ));
+            }
+            if old_pool_wallet.target_puzzle_hash != pool_wallet.target_puzzle_hash {
+                change_messages.push(format!(
+                    "from PH {} to PH {}",
+                    old_pool_wallet.target_puzzle_hash, pool_wallet.target_puzzle_hash
+                ));
+            }
+            if change_messages.is_empty() {
+                info!(
+                    "PlotNFT state for launcher id {} did not change",
+                    plot_nft.launcher_id.to_string(),
+                );
+            } else {
+                info!(
+                    "PlotNFT state for launcher id {} did change {}",
+                    plot_nft.launcher_id.to_string(),
+                    change_messages.join(" and "),
+                );
+            }
+        }
+    }
+
+    Ok(updated_config)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
-use crate::cli::{generate_config_from_mnemonic, update_pool_info, Action, Cli, GenerateConfig};
+use crate::cli::{
+    generate_config_from_mnemonic, join_pool, update_pool_info, Action, Cli, GenerateConfig,
+};
 use crate::farmer::config::{load_keys, Config};
 use crate::farmer::{Farmer, FarmerSharedState};
 use crate::tasks::pool_state_updater::pool_updater;
@@ -208,6 +210,31 @@ async fn main() -> Result<(), Error> {
                 .unwrap_or_default();
             let config = Config::try_from(&config_path).unwrap_or_default();
             let updated_config = update_pool_info(config).await?;
+            updated_config.save_as_yaml(config_path)?;
+
+            Ok(())
+        }
+        Action::JoinPool {
+            pool_url,
+            mnemonic,
+            launcher_id,
+            fee,
+        } => {
+            if !config_path.exists() {
+                eprintln!(
+                    "Failed to find config at {:?}, please run init",
+                    config_path
+                );
+                return Ok(());
+            }
+            SimpleLogger::new()
+                .with_colors(true)
+                .with_level(LevelFilter::Info)
+                .env()
+                .init()
+                .unwrap_or_default();
+            let config = Config::try_from(&config_path).unwrap_or_default();
+            let updated_config = join_pool(config, pool_url, mnemonic, launcher_id, fee).await?;
             updated_config.save_as_yaml(config_path)?;
 
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crate::cli::{generate_config_from_mnemonic, Action, Cli, GenerateConfig};
+use crate::cli::{generate_config_from_mnemonic, update_pool_info, Action, Cli, GenerateConfig};
 use crate::farmer::config::{load_keys, Config};
 use crate::farmer::{Farmer, FarmerSharedState};
 use crate::tasks::pool_state_updater::pool_updater;
@@ -190,6 +190,26 @@ async fn main() -> Result<(), Error> {
                 additional_headers: None,
             })
             .await?;
+            Ok(())
+        }
+        Action::UpdatePoolInfo {} => {
+            if !config_path.exists() {
+                eprintln!(
+                    "Failed to find config at {:?}, please run init",
+                    config_path
+                );
+                return Ok(());
+            }
+            SimpleLogger::new()
+                .with_colors(true)
+                .with_level(LevelFilter::Info)
+                .env()
+                .init()
+                .unwrap_or_default();
+            let config = Config::try_from(&config_path).unwrap_or_default();
+            let updated_config = update_pool_info(config).await?;
+            updated_config.save_as_yaml(config_path)?;
+
             Ok(())
         }
     }


### PR DESCRIPTION
Currently it is not possible to switch pools using fast farmer.

This PR adds a `join-pool` command which will ensure all or just a selected plot nft are joined to the pool specified. This requires the mnemonic again because when supplying a fee we need to sync the wallet and generate a signed tx.

- Depends on https://github.com/GalactechsLLC/dg_fast_farmer/pull/10